### PR TITLE
#9: Specify "path" as an annotation on the controller (closes #9)

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -49,6 +49,10 @@ lazy val serverAkkaHttp = project
     bintrayPackageLabels := Seq("buildo", "wiro", "wiro-http-server")
   )
   .dependsOn(core)
+  .dependsOn(macros)
+
+lazy val macros = project
+  .settings(commonSettings)
 
 lazy val examples = project
   .settings(commonSettings: _*)

--- a/core/src/main/scala/annotations.scala
+++ b/core/src/main/scala/annotations.scala
@@ -74,4 +74,5 @@ package object annotation {
       c.Expr[Any](result)
     }
   }
+
 }

--- a/docs/src/main/tut/index.md
+++ b/docs/src/main/tut/index.md
@@ -92,3 +92,33 @@ curl 'http://localhost:8080/UserController/find?id=3'
 ```
 
 `>> {"id":1,"username":"Pippo"}`
+
+## Specifying the controller path
+By default wiro uses the controller name in the generated path, as in `/UserController/find`.
+
+You can override this default by annotating the UserController with `@path`:
+
+```scala
+import wiro.annotation.path
+
+@path("custom")
+trait UserController {
+  // ...
+}
+```
+
+then overriding the `path` field in the `RouteGenerator` definition:
+
+```scala
+implicit def UserRouter = new RouteGenerator[UserController] {
+  val routes = route[UserController](userController)
+  val tp = typePath[UserController]
+  override val path = derivePath[UserController]
+}
+```
+
+Try this out:
+
+```bash
+curl 'http://localhost:8080/custom/find?id=3'
+```

--- a/examples/src/main/scala/Server.scala
+++ b/examples/src/main/scala/Server.scala
@@ -39,6 +39,7 @@ object Server extends App {
   implicit def DoghouseRouter = new RouteGenerator[DoghouseApiImpl] {
     val routes = route[DoghouseApi](doghouseApi)
     val tp = typePath[DoghouseApi]
+    override val path = derivePath[DoghouseApi]
   }
 
   implicit val system = ActorSystem()
@@ -62,6 +63,7 @@ object controllers {
 
   case class Nope(msg: String)
 
+  @path("woff")
   trait DoghouseApi {
     @token
     @query

--- a/macros/src/main/scala/PathMacro.scala
+++ b/macros/src/main/scala/PathMacro.scala
@@ -1,0 +1,27 @@
+package wiro.server.akkaHttp
+
+import scala.reflect.macros.blackbox.Context
+import scala.language.experimental.macros
+
+import wiro.annotation.path
+
+trait PathMacro {
+  def derivePath[A]: String = macro PathMacro.derivePathImpl[A]
+}
+
+object PathMacro extends PathMacro {
+  def derivePathImpl[A: c.WeakTypeTag](c: Context): c.Tree = {
+    import c.universe._
+
+    val tpe = weakTypeOf[A].typeSymbol
+
+    tpe.annotations.collectFirst {
+      case pathAnnotation if pathAnnotation.tpe <:< c.weakTypeOf[path] =>
+        pathAnnotation.tree.children.tail.head
+    }.headOption match {
+      case Some(name) => name
+      case None => c.abort(c.enclosingPosition, s"\n\nMissing annotation @path(<name>) on $tpe\n")
+    }
+
+  }
+}

--- a/macros/src/main/scala/annotations.scala
+++ b/macros/src/main/scala/annotations.scala
@@ -1,0 +1,6 @@
+package wiro.annotation
+
+import scala.annotation.StaticAnnotation
+
+class path(name: String) extends StaticAnnotation
+

--- a/serverAkkaHttp/src/main/scala/RPCRouter.scala
+++ b/serverAkkaHttp/src/main/scala/RPCRouter.scala
@@ -1,4 +1,5 @@
 package wiro.server.akkaHttp
+
 import akka.http.scaladsl.server.Directives._
 import akka.http.scaladsl.server._
 import akka.http.scaladsl.model.{ HttpResponse, StatusCodes }
@@ -19,7 +20,7 @@ import io.circe.syntax._
 object RouteGenerators {
   def exceptionHandler = ExceptionHandler {
     case f@FailException(_) => complete(f.response)
-  } 
+  }
 
   private[this] def requestToken: Directive1[Option[String]] = {
     val authDirective: Directive1[Option[String]] = headerValueByName("Authorization")
@@ -34,7 +35,7 @@ object RouteGenerators {
   }
 
   //TODO Don't necessarily need the type here, it can be simplified (no boxing)
-  trait RouteGenerator[A] extends RPCController {
+  trait RouteGenerator[A] extends RPCController with PathMacro {
     def routes: autowire.Core.Router[Json]
     //complete path of the trait implementation, required by autowire to locate the method
     def tp: Seq[String]


### PR DESCRIPTION
Issue #9

## Test Plan

### tests performed
Tested with the example:

- with the new annotation -> path changed
- without the annotation -> same behavior as before (it uses the name of the controller)
