### PR TITLE
#13: Improve error handling on circe decoder (closes #13)

### DIFF
--- a/examples/src/main/scala/Server.scala
+++ b/examples/src/main/scala/Server.scala
@@ -62,32 +62,22 @@ object controllers {
   import FailSupport._
 
   case class Nope(msg: String)
+  case class Wa(lol: String, bah: Int, dah: Int)
 
   @path("woff")
   trait DoghouseApi {
-    @token
-    @query
+    @command
     def getPuppy(
-      str: String,
-      dou: Double,
-      int: Int,
-      bol: Boolean
+      wa: Wa
     ): Future[Either[Nope, Dog]]
   }
 
   class DoghouseApiImpl() extends DoghouseApi {
-    @token
-    @query
+    @command
     override def getPuppy(
-      str: String,
-      dou: Double,
-      int: Int,
-      bol: Boolean
+      wa: Wa
     ): Future[Either[Nope, Dog]] = Future(Left{
-      println(str)
-      println(dou)
-      println(int)
-      println(bol)
+      println(wa)
       Nope("Not doing that")
     })
   }

--- a/serverAkkaHttp/src/main/scala/AutowireErrorsSupport.scala
+++ b/serverAkkaHttp/src/main/scala/AutowireErrorsSupport.scala
@@ -63,7 +63,7 @@ object AutowireErrorSupport {
           val path = CursorOp.opsToPath(history)
           complete(HttpResponse(
             status = StatusCodes.UnprocessableEntity,
-            entity = s"Failed decoding of '${path}' on type '${tpe}'"
+            entity = s"Failed decoding of '${path}' of type '${tpe}'"
           ))
         case _ =>
           complete(HttpResponse(

--- a/serverAkkaHttp/src/main/scala/RPCController.scala
+++ b/serverAkkaHttp/src/main/scala/RPCController.scala
@@ -7,9 +7,11 @@ trait RPCController extends autowire.Server[Json, Decoder, WiroEncoder] with Cus
   def write[Result: WiroEncoder](r: Result): Json =
     implicitly[WiroEncoder[Result]].encode(r)
 
-  //TODO handle circe error here
   def read[Result: Decoder](p: Json): Result =
-    p.as[Result].right.get
+    p.as[Result] match {
+      case Right(result) => result
+      case Left(error) => throw error
+    }
 
   def routes: Router
   def tp: Seq[String]


### PR DESCRIPTION
Issue #13

## Test Plan

### tests performed
> tested locally

```bash
curl -XPOST http://localhost:8080/woff/getPuppy-H "Content-Type: application/json" \
 -d '{"wa": {"lol":"ok", "bah": 1, "dah": true}}'

Failed decoding of '.dah' on type 'Int'
```