### PR TITLE
#54: Remove GeneratorBox (closes #54)

### DIFF
--- a/examples/src/main/scala/Server.scala
+++ b/examples/src/main/scala/Server.scala
@@ -13,8 +13,6 @@ import akka.stream.ActorMaterializer
 import akka.http.scaladsl.model.{ HttpResponse, StatusCodes, ContentType, HttpEntity}
 import akka.http.scaladsl.model.MediaTypes
 
-import wiro.server.akkaHttp.RouteGenerators._
-
 import io.circe.generic.auto._
 
 object controllers {
@@ -90,15 +88,15 @@ object Server extends App with RouterDerivationModule {
   import errors._
   import FailSupport._
 
-  val doghouseApi = new DoghouseApiImpl: DoghouseApi
-  implicit def DoghouseRouter = deriveRouter[DoghouseApi](doghouseApi)
+  val doghouseApi = new DoghouseApiImpl
+  val doghouseRouter = deriveRouter[DoghouseApi](doghouseApi)
 
   implicit val system = ActorSystem()
   implicit val materializer = ActorMaterializer()
 
   val rpcServer = new HttpRPCServer(
     config = Config("localhost", 8080),
-    controllers = List(doghouseApi)
+    routers = List(doghouseRouter)
   )
 }
 

--- a/examples/src/main/scala/Server.scala
+++ b/examples/src/main/scala/Server.scala
@@ -88,8 +88,7 @@ object Server extends App with RouterDerivationModule {
   import errors._
   import FailSupport._
 
-  val doghouseApi = new DoghouseApiImpl
-  val doghouseRouter = deriveRouter[DoghouseApi](doghouseApi)
+  val doghouseRouter = deriveRouter[DoghouseApi](new DoghouseApiImpl)
 
   implicit val system = ActorSystem()
   implicit val materializer = ActorMaterializer()

--- a/serverAkkaHttp/src/main/scala/RPCController.scala
+++ b/serverAkkaHttp/src/main/scala/RPCController.scala
@@ -3,7 +3,7 @@ package wiro.server.akkaHttp
 import io.circe._
 import wiro.{ CustomOptionDecoder, CustomBooleanDecoder }
 
-trait RPCController extends autowire.Server[Json, Decoder, WiroEncoder] with CustomOptionDecoder with CustomBooleanDecoder {
+trait RPCServer extends autowire.Server[Json, Decoder, WiroEncoder] with CustomOptionDecoder with CustomBooleanDecoder {
   def write[Result: WiroEncoder](r: Result): Json =
     implicitly[WiroEncoder[Result]].encode(r)
 
@@ -14,6 +14,4 @@ trait RPCController extends autowire.Server[Json, Decoder, WiroEncoder] with Cus
     }
 
   def routes: Router
-  def tp: Seq[String]
-  def path: String = tp.last
 }

--- a/serverAkkaHttp/src/main/scala/RPCServer.scala
+++ b/serverAkkaHttp/src/main/scala/RPCServer.scala
@@ -10,12 +10,11 @@ import akka.http.scaladsl.server.{ StandardRoute, Route }
 import scala.io.StdIn
 
 import wiro.models.Config
-import wiro.server.akkaHttp.RouteGenerators._
-import wiro.server.akkaHttp.RouteGenerators.BoxingSupport._
+import wiro.server.akkaHttp.{ Router => WiroRouter }
 
 class HttpRPCServer(
   config: Config,
-  controllers: List[GeneratorBox[_]],
+  routers: List[WiroRouter],
   customRoute: Route = reject
 )(implicit
   system: ActorSystem,
@@ -23,8 +22,8 @@ class HttpRPCServer(
 ) {
   import system.dispatcher
 
-  val route = controllers
-    .map(_.routify)
+  val route = routers
+    .map(_.buildRoute)
     .foldLeft(customRoute) (_ ~ _)
 
   val bindingFuture = Http().bindAndHandle(route, config.host, config.port)

--- a/serverAkkaHttp/src/main/scala/RouterDerivation.scala
+++ b/serverAkkaHttp/src/main/scala/RouterDerivation.scala
@@ -4,10 +4,8 @@ import scala.reflect.macros.blackbox.Context
 import scala.language.experimental.macros
 import wiro.annotation.path
 
-import RouteGenerators._
-
 trait RouterDerivationModule extends PathMacro with MetaDataMacro {
-  def deriveRouter[A](a: A): RouteGenerator[A] = macro RouterDerivationMacro.deriveRouterImpl[A]
+  def deriveRouter[A](a: A): Router = macro RouterDerivationMacro.deriveRouterImpl[A]
 }
 
 object RouterDerivationMacro extends RouterDerivationModule {
@@ -26,9 +24,9 @@ object RouterDerivationMacro extends RouterDerivationModule {
     }
 
     q"""
-    import wiro.server.akkaHttp.{ OperationType, AuthenticationType, MethodMetaData }
+    import wiro.server.akkaHttp.{ OperationType, AuthenticationType, MethodMetaData, Router }
 
-    new RouteGenerator[$tpe] {
+    new Router {
       override val routes = route[$tpe]($a)
       override val methodsMetaData = deriveMetaData[$tpe]
       override val tp = typePath[$tpe]

--- a/serverAkkaHttp/src/test/scala/TestController.scala
+++ b/serverAkkaHttp/src/test/scala/TestController.scala
@@ -11,7 +11,6 @@ import wiro.annotation._
 import wiro.reflect._
 import wiro.server.akkaHttp._
 import wiro.server.akkaHttp.FailSupport._
-import wiro.server.akkaHttp.RouteGenerators._
 
 object TestController extends RouterDerivationModule {
   case class UserNotFound(userId: Int)
@@ -96,6 +95,6 @@ object TestController extends RouterDerivationModule {
     }
   }
 
-  private[this] val userController = new UserControllerImpl(): UserController
+  private[this] val userController = new UserControllerImpl()
   def userRouter = deriveRouter[UserController](userController)
 }


### PR DESCRIPTION
Closes #54

`deriveRouter` now returns a `Router` object.
Removed type class boxing.

## Test Plan

### tests performed
- tests are passing