### PR TITLE
Use sbt-release to simplify the release process

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -35,8 +35,21 @@ lazy val commonSettings = Seq(
     commonDependencies :+
     scalaOrganization.value % "scala-reflect" % scalaVersion.value % "provided",
   addCompilerPlugin("org.scalamacros" % "paradise" % "2.1.0" cross CrossVersion.full),
-  scalacOptions += "-Xplugin-require:macroparadise"
+  scalacOptions += "-Xplugin-require:macroparadise",
+  releaseCrossBuild := true
 )
+
+lazy val noPublishSettings = Seq(
+  publish := (),
+  publishLocal := (),
+  publishArtifact := false
+)
+
+lazy val root = project.in(file("."))
+  .settings(commonSettings)
+  .settings(noPublishSettings)
+  .aggregate(core, serverAkkaHttp, clientAkkaHttp, macros)
+  .dependsOn(core, serverAkkaHttp, clientAkkaHttp, macros)
 
 lazy val core = project
   .settings(commonSettings: _*)

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -11,3 +11,5 @@ addSbtPlugin("org.tpolecat" % "tut-plugin" % "0.4.8")
 resolvers += "jgit-repo" at "http://download.eclipse.org/jgit/maven"
 
 addSbtPlugin("com.typesafe.sbt" % "sbt-ghpages" % "0.5.4")
+
+addSbtPlugin("com.github.gseitz" % "sbt-release" % "1.0.5")

--- a/version.sbt
+++ b/version.sbt
@@ -1,0 +1,1 @@
+version in ThisBuild := "0.3.1-SNAPSHOT"


### PR DESCRIPTION
Now `sbt release` should take care of publishing all subprojects, bumping the version and setting the git tags.