### PR TITLE
Refactored `CustomBooleanDecoder` to use existing circe `Decoder`s

### DIFF
--- a/core/src/main/scala/BooleanDecoder.scala
+++ b/core/src/main/scala/BooleanDecoder.scala
@@ -1,24 +1,10 @@
 package wiro
 
-import io.circe._
-import scala.util.{ Try, Success, Failure }
+import io.circe.Decoder
+import scala.util.Try
 
-//This code is modified from circe (https://github.com/circe/circe).
-//Circe is licensed under http://www.apache.org/licenses/LICENSE-2.0
-//With the following notice https://github.com/circe/circe/blob/master/NOTICE.
 trait CustomBooleanDecoder {
-  implicit final val decodeBoolean: Decoder[Boolean] = new Decoder[Boolean] {
-    private[this] def fail(c: HCursor) = Left(DecodingFailure("Boolean", c.history))
-
-    final def apply(c: HCursor): Decoder.Result[Boolean] = c.value.asBoolean match {
-      case Some(b) => Right(b)
-      case None => c.value.asString match {
-        case Some(s) => Try(s.toBoolean) match {
-          case Success(v) => Right(v)
-          case Failure(_) => fail(c)
-        }
-        case None => fail(c)
-      }
-    }
-  }
+  private[this] def asBoolean(s: String) = Try(s.toBoolean)
+  implicit final val decodeBoolean: Decoder[Boolean] =
+    Decoder.decodeBoolean or Decoder.decodeString.emapTry(asBoolean).withErrorMessage("Boolean")
 }


### PR DESCRIPTION
Combined circe existing `Decoder`s instead of defining a new one.