### PR TITLE
Simplify `CustomOptionDecoder` implementation

### DIFF
--- a/core/src/main/scala/OptionDecoder.scala
+++ b/core/src/main/scala/OptionDecoder.scala
@@ -7,20 +7,7 @@ import cats.data.Validated
 //Circe is licensed under http://www.apache.org/licenses/LICENSE-2.0
 //with the following notice https://github.com/circe/circe/blob/master/NOTICE.
 trait CustomOptionDecoder {
-  final def withReattempt[A](f: ACursor => Decoder.Result[A]): Decoder[A] = new Decoder[A] {
-    final def apply(c: HCursor): Decoder.Result[A] = tryDecode(c)
-
-    override def tryDecode(c: ACursor): Decoder.Result[A] = f(c)
-
-    override def decodeAccumulating(c: HCursor): AccumulatingDecoder.Result[A] = tryDecodeAccumulating(c)
-
-    override def tryDecodeAccumulating(c: ACursor): AccumulatingDecoder.Result[A] = f(c) match {
-      case Right(v) => Validated.valid(v)
-      case Left(e) => Validated.invalidNel(e)
-    }
-  }
-
-  implicit final def decodeOption[A](implicit d: Decoder[A]): Decoder[Option[A]] = withReattempt {
+  implicit final def decodeOption[A](implicit d: Decoder[A]): Decoder[Option[A]] = Decoder.withReattempt {
     case c: HCursor =>
       if (c.value.isNull) rightNone else d(c) match {
         case Right(a) => Right(Some(a))

--- a/core/src/main/scala/OptionDecoder.scala
+++ b/core/src/main/scala/OptionDecoder.scala
@@ -1,6 +1,6 @@
 package wiro
 
-import io.circe._
+import io.circe.{ Decoder, FailedCursor, DecodingFailure, HCursor }
 
 //This code is modified from circe (https://github.com/circe/circe).
 //Circe is licensed under http://www.apache.org/licenses/LICENSE-2.0

--- a/core/src/main/scala/OptionDecoder.scala
+++ b/core/src/main/scala/OptionDecoder.scala
@@ -1,7 +1,6 @@
 package wiro
 
 import io.circe._
-import cats.data.Validated
 
 //This code is modified from circe (https://github.com/circe/circe).
 //Circe is licensed under http://www.apache.org/licenses/LICENSE-2.0


### PR DESCRIPTION
## description
Removed "unneeded" code from`CustomOptionDecoder`.

## specs
- Removed `withReattempt` method because it is just an unmodified [copy/paste](https://github.com/circe/circe/blob/314a65347b28e5a53061564be53cec87745411bb/modules/core/shared/src/main/scala/io/circe/Decoder.scala#L366) from circe `io.circe.Decoder` utilities;
- Removed also (now) unneeded `cats.data.Validated` import;
- Refined circe imports.
