### PR TITLE
Simplified `derivePath` within router derivation macro

### DIFF
--- a/core/src/main/scala/MetaDataMacro.scala
+++ b/core/src/main/scala/MetaDataMacro.scala
@@ -30,10 +30,10 @@ object MetaDataMacro extends MetaDataMacro {
       case m: MethodSymbol =>
         val methodName = m.fullName
         val operationType = m.annotations.collectFirst {
-          case opAnnotation if opAnnotation.tree.tpe <:< c.weakTypeOf[command] =>
+          case opAnnotation if opAnnotation.tree.tpe <:< weakTypeOf[command] =>
             val name = opAnnotation.tree.children.tail.head
             q"OperationType.Command($name)"
-          case opAnnotation if opAnnotation.tree.tpe <:< c.weakTypeOf[query] =>
+          case opAnnotation if opAnnotation.tree.tpe <:< weakTypeOf[query] =>
             val name = opAnnotation.tree.children.tail.head
             q"OperationType.Query($name)"
         }

--- a/core/src/main/scala/PathMacro.scala
+++ b/core/src/main/scala/PathMacro.scala
@@ -16,7 +16,7 @@ object PathMacro extends PathMacro {
     val tpe = weakTypeOf[A].typeSymbol
 
     tpe.annotations.collectFirst {
-      case pathAnnotation if pathAnnotation.tree.tpe <:< c.weakTypeOf[path] =>
+      case pathAnnotation if pathAnnotation.tree.tpe <:< weakTypeOf[path] =>
         pathAnnotation.tree.children.tail.head
     }.getOrElse {
       c.abort(c.enclosingPosition, s"\n\nMissing annotation @path(<name>) on $tpe\n")

--- a/serverAkkaHttp/src/main/scala/RouterDerivation.scala
+++ b/serverAkkaHttp/src/main/scala/RouterDerivation.scala
@@ -16,14 +16,10 @@ object RouterDerivationMacro extends RouterDerivationModule {
     val tpe = weakTypeOf[A]
 
     //check only annotations of path type
-    val pathAnnotated = tpe.typeSymbol.annotations.collectFirst {
-      case pathAnnotation if pathAnnotation.tree.tpe <:< c.weakTypeOf[path] => pathAnnotation
-    }
-
-    val derivePath = pathAnnotated match {
-      case None => EmptyTree
-      case _ => q"override val path = derivePath[$tpe]"
-    }
+    val derivePath = tpe.typeSymbol.annotations.collectFirst {
+      case pathAnnotation if pathAnnotation.tree.tpe <:< c.weakTypeOf[path] =>
+        q"override val path = derivePath[$tpe]"
+    }.getOrElse(EmptyTree)
 
     q"""
     import wiro.{ OperationType, MethodMetaData }

--- a/serverAkkaHttp/src/main/scala/RouterDerivation.scala
+++ b/serverAkkaHttp/src/main/scala/RouterDerivation.scala
@@ -17,7 +17,7 @@ object RouterDerivationMacro extends RouterDerivationModule {
 
     //check only annotations of path type
     val derivePath = tpe.typeSymbol.annotations.collectFirst {
-      case pathAnnotation if pathAnnotation.tree.tpe <:< c.weakTypeOf[path] =>
+      case pathAnnotation if pathAnnotation.tree.tpe <:< weakTypeOf[path] =>
         q"override val path = derivePath[$tpe]"
     }.getOrElse(EmptyTree)
 


### PR DESCRIPTION
## description
- Simplified `derivePath` using `getOrElse` instead of matching on`pathAnnotated` and discarding the actual collected value;
- Bonus: removed unneeded reference to `c: Context`.