### PR TITLE
Simplified `requestToken` directive

### DIFF
--- a/serverAkkaHttp/src/main/scala/RPCRouter.scala
+++ b/serverAkkaHttp/src/main/scala/RPCRouter.scala
@@ -45,12 +45,10 @@ trait Router extends RPCServer with PathMacro with MetaDataMacro {
 
   private[this] val requestToken: Directive1[Option[String]] = {
     val TokenPattern = "Token token=(.+)".r
-    val authDirective: Directive1[Option[String]] =
-      headerValueByName("Authorization").flatMap {
-        case TokenPattern(token) => provide(Some(token))
-        case _                   => provide(None)
-      }
-    authDirective.recover { x => provide(None) }
+    optionalHeaderValueByName("Authorization").flatMap {
+      case Some(TokenPattern(token)) => provide(Some(token))
+      case _                         => provide(None)
+    }
   }
 
   private[this] def operationName(operationFullName: String, methodMetaData: MethodMetaData): String =

--- a/serverAkkaHttp/src/main/scala/RPCRouter.scala
+++ b/serverAkkaHttp/src/main/scala/RPCRouter.scala
@@ -45,9 +45,9 @@ trait Router extends RPCServer with PathMacro with MetaDataMacro {
 
   private[this] val requestToken: Directive1[Option[String]] = {
     val TokenPattern = "Token token=(.+)".r
-    optionalHeaderValueByName("Authorization").flatMap {
-      case Some(TokenPattern(token)) => provide(Some(token))
-      case _                         => provide(None)
+    optionalHeaderValueByName("Authorization").map {
+      case Some(TokenPattern(token)) => Some(token)
+      case _                         => None
     }
   }
 

--- a/serverAkkaHttp/src/main/scala/RPCRouter.scala
+++ b/serverAkkaHttp/src/main/scala/RPCRouter.scala
@@ -44,13 +44,11 @@ trait Router extends RPCServer with PathMacro with MetaDataMacro {
   }
 
   private[this] val requestToken: Directive1[Option[String]] = {
-    val authDirective: Directive1[Option[String]] = headerValueByName("Authorization")
-      .flatMap { header =>
-        val TokenPattern = "Token token=(.+)".r
-        header match {
-          case TokenPattern(token) => provide(Some(token))
-          case _                   => provide(None)
-        }
+    val TokenPattern = "Token token=(.+)".r
+    val authDirective: Directive1[Option[String]] =
+      headerValueByName("Authorization").flatMap {
+        case TokenPattern(token) => provide(Some(token))
+        case _                   => provide(None)
       }
     authDirective.recover { x => provide(None) }
   }

--- a/serverAkkaHttp/src/main/scala/RPCRouter.scala
+++ b/serverAkkaHttp/src/main/scala/RPCRouter.scala
@@ -43,7 +43,7 @@ trait Router extends RPCServer with PathMacro with MetaDataMacro {
     case f@FailException(_) => complete(f.response)
   }
 
-  private[this] def requestToken: Directive1[Option[String]] = {
+  private[this] val requestToken: Directive1[Option[String]] = {
     val authDirective: Directive1[Option[String]] = headerValueByName("Authorization")
       .flatMap { header =>
         val TokenPattern = "Token token=(.+)".r


### PR DESCRIPTION
## description
Simplified the `requestToken` directive.

## specs
- Made `requestToken` a val instead of a def. Since `requestToken` is private we should not be worried to declare it as a val;
- Simplified code removing unnecessary verbosity;
- Replaced `headerValueByName` followed by `recover` with `optionalHeaderValueByName`;
- Use of `map` instead of `flatMap`.

## drawbacks
The removed `recover` was recovering also from other types of rejection aside from the missing header rejection (the `MissingHeaderRejection`). Was this a requirement?