### PR TITLE
Simplified `RPCRouter` and `RPCServer` codebase

### DIFF
--- a/serverAkkaHttp/src/main/scala/RPCController.scala
+++ b/serverAkkaHttp/src/main/scala/RPCController.scala
@@ -3,15 +3,14 @@ package wiro.server.akkaHttp
 import io.circe._
 import wiro.{ CustomOptionDecoder, CustomBooleanDecoder }
 
+import cats.syntax.either._
+
 trait RPCServer extends autowire.Server[Json, Decoder, WiroEncoder] with CustomOptionDecoder with CustomBooleanDecoder {
   def write[Result: WiroEncoder](r: Result): Json =
     implicitly[WiroEncoder[Result]].encode(r)
 
   def read[Result: Decoder](p: Json): Result =
-    p.as[Result] match {
-      case Right(result) => result
-      case Left(error) => throw error
-    }
+    p.as[Result].toTry.get
 
   def routes: Router
 }

--- a/serverAkkaHttp/src/main/scala/RPCRouter.scala
+++ b/serverAkkaHttp/src/main/scala/RPCRouter.scala
@@ -88,18 +88,14 @@ trait Router extends RPCServer with PathMacro with MetaDataMacro {
   }
 
   def commandArgs(request: Json, token: Option[String]): Map[String, Json] =
-    request.as[Map[String, Json]].right.get.withToken(token)
+    request.as[Map[String, Json]].right.get ++ token.map(tokenAsArg)
 
   private[this] def parseJsonOrString(s: String): Json =
     parse(s).getOrElse(Json.fromString(s))
 
   def queryArgs(params: Map[String, String], token: Option[String]): Map[String, Json] =
-    params.mapValues(parseJsonOrString).withToken(token)
+    params.mapValues(parseJsonOrString) ++ token.map(tokenAsArg)
 
-  implicit class PimpMyMap(m: Map[String, Json]) {
-    def withToken(token: Option[String]): Map[String, Json] = token match {
-      case Some(t) => m + ("token" -> Json.obj("token" -> Json.fromString(t)))
-      case None => m
-    }
-  }
+  private[this] def tokenAsArg(token: String): (String, Json) =
+    "token" -> Json.obj("token" -> Json.fromString(token))
 }

--- a/serverAkkaHttp/src/main/scala/RPCRouter.scala
+++ b/serverAkkaHttp/src/main/scala/RPCRouter.scala
@@ -3,26 +3,17 @@ package server.akkaHttp
 
 import AutowireErrorSupport._
 
-import akka.http.scaladsl.model.{ HttpResponse, StatusCodes }
 import akka.http.scaladsl.server.Directives._
 import akka.http.scaladsl.server.{ Directive0, Directive1, ExceptionHandler, Route }
 
-import cats.syntax.traverse._
-import cats.instances.map._
-import cats.instances.either._
 import cats.syntax.either._
 
 import de.heikoseeberger.akkahttpcirce.ErrorAccumulatingCirceSupport._
 
 import FailSupport._
 
-import io.circe.{ Json, JsonObject, ParsingFailure }
+import io.circe.{ Json, JsonObject }
 import io.circe.parser._
-
-import scala.language.implicitConversions
-
-import scala.util.{ Try, Success, Failure }
-import scala.concurrent.Future
 
 trait Router extends RPCServer with PathMacro with MetaDataMacro {
   def tp: Seq[String]

--- a/serverAkkaHttp/src/main/scala/RPCRouter.scala
+++ b/serverAkkaHttp/src/main/scala/RPCRouter.scala
@@ -64,15 +64,10 @@ trait Router extends RPCServer with PathMacro with MetaDataMacro {
   private[this] def query(operationFullName: String, methodMetaData: MethodMetaData): Route = {
     (routePathPrefix(operationFullName, methodMetaData) & pathEnd & get & parameterMap) { params =>
       requestToken { token =>
-        val appliedRequest = Try(routes(autowireRequest(
+        Either.catchNonFatal(routes(autowireRequest(
           operationFullName,
           params.mapValues(parseJsonOrString) ++ token.map(tokenAsArg)
-        )))
-
-        appliedRequest match {
-          case Success(res) => complete(res)
-          case Failure(f) => handleUnwrapErrors(f)
-        }
+        ))).fold(handleUnwrapErrors, result => complete(result))
       }
     }
   }
@@ -84,15 +79,10 @@ trait Router extends RPCServer with PathMacro with MetaDataMacro {
   private[this] def command(operationFullName: String, methodMetaData: MethodMetaData): Route = {
     (routePathPrefix(operationFullName, methodMetaData) & pathEnd & post & entity(as[JsonObject])) { request =>
       requestToken { token =>
-        val appliedRequest = Try(routes(autowireRequest(
+        Either.catchNonFatal(routes(autowireRequest(
           operationFullName,
           request.toMap ++ token.map(tokenAsArg)
-        )))
-
-        appliedRequest match {
-          case Success(res) => complete(res)
-          case Failure(f) => handleUnwrapErrors(f)
-        }
+        ))).fold(handleUnwrapErrors, result => complete(result))
       }
     }
   }

--- a/serverAkkaHttp/src/main/scala/RPCRouter.scala
+++ b/serverAkkaHttp/src/main/scala/RPCRouter.scala
@@ -16,7 +16,7 @@ import de.heikoseeberger.akkahttpcirce.ErrorAccumulatingCirceSupport._
 
 import FailSupport._
 
-import io.circe.{ Json, ParsingFailure }
+import io.circe.{ Json, JsonObject, ParsingFailure }
 import io.circe.parser._
 
 import scala.language.implicitConversions
@@ -72,7 +72,7 @@ trait Router extends RPCServer with PathMacro with MetaDataMacro {
 
   //Generates POST requests
   private[this] def command(operationFullName: String, methodMetaData: MethodMetaData): Route = {
-    (pathPrefix(operationName(operationFullName, methodMetaData)) & pathEnd & post & entity(as[Json])) { request =>
+    (pathPrefix(operationName(operationFullName, methodMetaData)) & pathEnd & post & entity(as[JsonObject])) { request =>
       requestToken { token =>
         val appliedRequest = Try(routes(autowire.Core.Request(
           path = operationFullName.split("""\."""),
@@ -87,8 +87,8 @@ trait Router extends RPCServer with PathMacro with MetaDataMacro {
     }
   }
 
-  def commandArgs(request: Json, token: Option[String]): Map[String, Json] =
-    request.as[Map[String, Json]].right.get ++ token.map(tokenAsArg)
+  def commandArgs(request: JsonObject, token: Option[String]): Map[String, Json] =
+    request.toMap ++ token.map(tokenAsArg)
 
   private[this] def parseJsonOrString(s: String): Json =
     parse(s).getOrElse(Json.fromString(s))

--- a/serverAkkaHttp/src/main/scala/RPCRouter.scala
+++ b/serverAkkaHttp/src/main/scala/RPCRouter.scala
@@ -5,7 +5,7 @@ import AutowireErrorSupport._
 
 import akka.http.scaladsl.model.{ HttpResponse, StatusCodes }
 import akka.http.scaladsl.server.Directives._
-import akka.http.scaladsl.server.{ Directive1, ExceptionHandler, Route }
+import akka.http.scaladsl.server.{ Directive0, Directive1, ExceptionHandler, Route }
 
 import cats.syntax.traverse._
 import cats.instances.map._
@@ -58,7 +58,7 @@ trait Router extends RPCServer with PathMacro with MetaDataMacro {
     methodMetaData.operationType.name.getOrElse(operationPath(operationFullName).last)
 
   private[this] def query(operationFullName: String, methodMetaData: MethodMetaData): Route = {
-    (pathPrefix(operationName(operationFullName, methodMetaData)) & pathEnd & get & parameterMap) { params =>
+    (routePathPrefix(operationFullName, methodMetaData) & pathEnd & get & parameterMap) { params =>
       requestToken { token =>
         val appliedRequest = Try(routes(autowire.Core.Request(
           path = operationPath(operationFullName),
@@ -73,9 +73,12 @@ trait Router extends RPCServer with PathMacro with MetaDataMacro {
     }
   }
 
+  private[this] def routePathPrefix(operationFullName: String, methodMetaData: MethodMetaData): Directive0 =
+    pathPrefix(operationName(operationFullName, methodMetaData))
+
   //Generates POST requests
   private[this] def command(operationFullName: String, methodMetaData: MethodMetaData): Route = {
-    (pathPrefix(operationName(operationFullName, methodMetaData)) & pathEnd & post & entity(as[JsonObject])) { request =>
+    (routePathPrefix(operationFullName, methodMetaData) & pathEnd & post & entity(as[JsonObject])) { request =>
       requestToken { token =>
         val appliedRequest = Try(routes(autowire.Core.Request(
           path = operationPath(operationFullName),

--- a/serverAkkaHttp/src/main/scala/RPCRouter.scala
+++ b/serverAkkaHttp/src/main/scala/RPCRouter.scala
@@ -32,10 +32,10 @@ trait Router extends RPCServer with PathMacro with MetaDataMacro {
 
   def buildRoute: Route = handleExceptions(exceptionHandler) {
     pathPrefix(path) {
-      methodsMetaData map {
+      methodsMetaData.map {
         case (k, v @ MethodMetaData(OperationType.Command(_))) => command(k, v)
         case (k, v @ MethodMetaData(OperationType.Query(_)))   => query(k, v)
-      } reduce (_ ~ _)
+      }.reduce(_ ~ _)
     }
   }
 

--- a/serverAkkaHttp/src/main/scala/RPCRouter.scala
+++ b/serverAkkaHttp/src/main/scala/RPCRouter.scala
@@ -57,6 +57,7 @@ trait Router extends RPCServer with PathMacro with MetaDataMacro {
   private[this] def operationName(operationFullName: String, methodMetaData: MethodMetaData): String =
     methodMetaData.operationType.name.getOrElse(operationPath(operationFullName).last)
 
+  //Generates GET requests
   private[this] def query(operationFullName: String, methodMetaData: MethodMetaData): Route = {
     (routePathPrefix(operationFullName, methodMetaData) & pathEnd & get & parameterMap) { params =>
       requestToken { token =>

--- a/serverAkkaHttp/src/main/scala/RPCRouter.scala
+++ b/serverAkkaHttp/src/main/scala/RPCRouter.scala
@@ -91,10 +91,7 @@ trait Router extends RPCServer with PathMacro with MetaDataMacro {
     request.as[Map[String, Json]].right.get.withToken(token)
 
   private[this] def parseJsonOrString(s: String): Json =
-    parse(s) match {
-      case Left(_) => Json.fromString(s)
-      case Right(other) => other
-    }
+    parse(s).getOrElse(Json.fromString(s))
 
   def queryArgs(params: Map[String, String], token: Option[String]): Map[String, Json] =
     params.mapValues(parseJsonOrString).withToken(token)

--- a/serverAkkaHttp/src/main/scala/RPCRouter.scala
+++ b/serverAkkaHttp/src/main/scala/RPCRouter.scala
@@ -51,14 +51,17 @@ trait Router extends RPCServer with PathMacro with MetaDataMacro {
     }
   }
 
+  private[this] def operationPath(operationFullName: String): Array[String] =
+    operationFullName.split('.')
+
   private[this] def operationName(operationFullName: String, methodMetaData: MethodMetaData): String =
-    methodMetaData.operationType.name.getOrElse(operationFullName.split("""\.""").last)
+    methodMetaData.operationType.name.getOrElse(operationPath(operationFullName).last)
 
   private[this] def query(operationFullName: String, methodMetaData: MethodMetaData): Route = {
     (pathPrefix(operationName(operationFullName, methodMetaData)) & pathEnd & get & parameterMap) { params =>
       requestToken { token =>
         val appliedRequest = Try(routes(autowire.Core.Request(
-          path = operationFullName.split("""\."""),
+          path = operationPath(operationFullName),
           args = queryArgs(params, token)
         )))
 
@@ -75,7 +78,7 @@ trait Router extends RPCServer with PathMacro with MetaDataMacro {
     (pathPrefix(operationName(operationFullName, methodMetaData)) & pathEnd & post & entity(as[JsonObject])) { request =>
       requestToken { token =>
         val appliedRequest = Try(routes(autowire.Core.Request(
-          path = operationFullName.split("""\."""),
+          path = operationPath(operationFullName),
           args = commandArgs(request, token)
         )))
 

--- a/serverAkkaHttp/src/main/scala/RPCRouter.scala
+++ b/serverAkkaHttp/src/main/scala/RPCRouter.scala
@@ -58,15 +58,15 @@ trait Router extends RPCServer with PathMacro with MetaDataMacro {
   private[this] def autowireRequestRouteWithToken(operationFullName: String, args: Map[String, Json]): Route =
     requestToken(token => autowireRequestRoute(operationFullName, args ++ token.map(tokenAsArg)))
 
+  private[this] def routePathPrefix(operationFullName: String, methodMetaData: MethodMetaData): Directive0 =
+    pathPrefix(operationName(operationFullName, methodMetaData))
+
   //Generates GET requests
   private[this] def query(operationFullName: String, methodMetaData: MethodMetaData): Route =
     (routePathPrefix(operationFullName, methodMetaData) & pathEnd & get & parameterMap) { params =>
       val args = params.mapValues(parseJsonOrString)
       autowireRequestRouteWithToken(operationFullName, args)
     }
-
-  private[this] def routePathPrefix(operationFullName: String, methodMetaData: MethodMetaData): Directive0 =
-    pathPrefix(operationName(operationFullName, methodMetaData))
 
   //Generates POST requests
   private[this] def command(operationFullName: String, methodMetaData: MethodMetaData): Route =

--- a/serverAkkaHttp/src/main/scala/RPCRouter.scala
+++ b/serverAkkaHttp/src/main/scala/RPCRouter.scala
@@ -62,7 +62,7 @@ trait Router extends RPCServer with PathMacro with MetaDataMacro {
       requestToken { token =>
         val appliedRequest = Try(routes(autowire.Core.Request(
           path = operationPath(operationFullName),
-          args = queryArgs(params, token)
+          args = params.mapValues(parseJsonOrString) ++ token.map(tokenAsArg)
         )))
 
         appliedRequest match {
@@ -79,7 +79,7 @@ trait Router extends RPCServer with PathMacro with MetaDataMacro {
       requestToken { token =>
         val appliedRequest = Try(routes(autowire.Core.Request(
           path = operationPath(operationFullName),
-          args = commandArgs(request, token)
+          args = request.toMap ++ token.map(tokenAsArg)
         )))
 
         appliedRequest match {
@@ -90,14 +90,9 @@ trait Router extends RPCServer with PathMacro with MetaDataMacro {
     }
   }
 
-  def commandArgs(request: JsonObject, token: Option[String]): Map[String, Json] =
-    request.toMap ++ token.map(tokenAsArg)
 
   private[this] def parseJsonOrString(s: String): Json =
     parse(s).getOrElse(Json.fromString(s))
-
-  def queryArgs(params: Map[String, String], token: Option[String]): Map[String, Json] =
-    params.mapValues(parseJsonOrString) ++ token.map(tokenAsArg)
 
   private[this] def tokenAsArg(token: String): (String, Json) =
     "token" -> Json.obj("token" -> Json.fromString(token))

--- a/serverAkkaHttp/src/main/scala/RPCRouter.scala
+++ b/serverAkkaHttp/src/main/scala/RPCRouter.scala
@@ -40,7 +40,7 @@ trait Router extends RPCServer with PathMacro with MetaDataMacro {
   }
 
   def exceptionHandler = ExceptionHandler {
-    case f@FailException(_) => complete(f.response)
+    case f: FailException[_] => complete(f.response)
   }
 
   private[this] val requestToken: Directive1[Option[String]] = {


### PR DESCRIPTION
## description
The goal of this PR is not to enhance/enrich wiro from functionalities, instead it is focused on codebase improvement from a readability point of view, mainly extracting helpers and removing redundancies.

## specs
- Simplified `RPCServer.read` using cats `.toTry`;
- Removed postfix operators from `buildRoute`;
- Match directly against `FailException` type within `exceptionHandler`;
- Simplified `parseJsonOrString` using cats `getOrElse`;
- Replaced implicit class `PimpMyMap` with a standard method `tokenAsArg`. It was public by mistake, confirmed with @calippo;
- **Require command args entity to be `JsonObject` instead of `Json`**. Note: old code `request.as[Map[String, Json]].right.get` was unsafe as well, asking for a `JsonObject` has exactly same rejection pattern;
- **Use `Either.catchNonFatal` instead of `Try`**;
- **Added `operationPath` method split helper using single character `.` instead of escaped regex string `”””\.”””`**;
- Removed `commandArgs` and `queryArgs`, they where public by mistake, confirmed with @calippo;
- Added `routePathPrefix`, `autowireRequestRoute` and `autowireRequestRouteWithToken` helpers;
- Refined imports.

