### PR TITLE
Added `FailSupport` to wiro client

### DIFF
--- a/clientAkkaHttp/src/main/scala/FailSupport.scala
+++ b/clientAkkaHttp/src/main/scala/FailSupport.scala
@@ -1,0 +1,21 @@
+package wiro.client.akkaHttp
+
+import io.circe.{ Decoder, Json, DecodingFailure }
+import cats.data.{ NonEmptyList,ValidatedNel }
+import cats.syntax.either._
+
+object FailSupport {
+  implicit def wiroCanFailDecoder[T: Decoder, A: Decoder] = new WiroDecoder[Either[T, A]] {
+    private[this] def decodeLeft(j: Json): Decoder.Result[Left[T, A]] = j.as[T].map(Left.apply)
+    private[this] def decodeRight(j: Json): Decoder.Result[Right[T, A]] = j.as[A].map(Right.apply)
+
+    private[this] def decodeEither(j: Json): ValidatedNel[DecodingFailure, Either[T, A]] =
+      decodeRight(j).toValidatedNel findValid decodeLeft(j).toValidatedNel
+    private[this] def errorMessage(errorList: NonEmptyList[DecodingFailure]) =
+      errorList.map(_.getMessage).toList.mkString
+
+    def decode(j: Json): Either[T, A] = decodeEither(j).fold(
+      error => throw new Exception(errorMessage(error)), identity
+    )
+  }
+}

--- a/clientAkkaHttp/src/main/scala/FailSupport.scala
+++ b/clientAkkaHttp/src/main/scala/FailSupport.scala
@@ -1,8 +1,9 @@
 package wiro.client.akkaHttp
 
-import io.circe.{ Decoder, Json, DecodingFailure }
-import cats.data.{ NonEmptyList,ValidatedNel }
+import cats.data.{ NonEmptyList, ValidatedNel }
 import cats.syntax.either._
+
+import io.circe.{ Decoder, DecodingFailure, Json }
 
 object FailSupport {
   implicit def wiroCanFailDecoder[T: Decoder, A: Decoder] = new WiroDecoder[Either[T, A]] {

--- a/clientAkkaHttp/src/main/scala/RPCClient.scala
+++ b/clientAkkaHttp/src/main/scala/RPCClient.scala
@@ -33,17 +33,8 @@ class RPCClient(
 
   def write[Result: Encoder](r: Result): Json = r.asJson
 
-  def read[Result: Decoder](p: Json): Result = {
-    //This trick is required to match the result type of autowire
-    val right = Json.obj("Right" -> Json.obj("b" -> p))
-    val left = Json.obj("Left" -> Json.obj("a" -> p))
-    (left.as[Result], right.as[Result]) match {
-      case (_, Right(result)) => result
-      case (Right(result), _) => result
-      case (Left(error1), Left(error2))  =>
-        throw new Exception(error1.getMessage + error2.getMessage)
-    }
-  }
+  def read[Result: WiroDecoder](p: Json): Result =
+    implicitly[WiroDecoder[Result]].decode(p)
 
   override def doCall(autowireRequest: Request): Future[Json] =
     Http().singleRequest(requestBuilder.build(autowireRequest.path, autowireRequest.args))

--- a/clientAkkaHttp/src/main/scala/RPCClient.scala
+++ b/clientAkkaHttp/src/main/scala/RPCClient.scala
@@ -28,8 +28,8 @@ class RPCClient(
   system: ActorSystem,
   materializer: ActorMaterializer,
   executionContext: ExecutionContext
-) extends autowire.Client[Json, Decoder, Encoder] {
-  private[this] val requestBuilder = new RequestBuilder(config, ctx)
+) extends autowire.Client[Json, WiroDecoder, Encoder] {
+  private[wiro] val requestBuilder = new RequestBuilder(config, ctx)
 
   def write[Result: Encoder](r: Result): Json = r.asJson
 

--- a/clientAkkaHttp/src/main/scala/package.scala
+++ b/clientAkkaHttp/src/main/scala/package.scala
@@ -1,0 +1,9 @@
+package wiro.client
+
+import io.circe.Json
+
+package object akkaHttp {
+  trait WiroDecoder[A] {
+    def decode(j: Json): A
+  }
+}

--- a/serverAkkaHttp/src/main/scala/FailSupport.scala
+++ b/serverAkkaHttp/src/main/scala/FailSupport.scala
@@ -9,9 +9,6 @@ object FailSupport {
   }
 
   implicit def wiroCanFailEncoder[T: ToHttpResponse, A: Encoder] = new WiroEncoder[Either[T, A]] {
-    def encode(d: Either[T, A]): Json = d match {
-      case Right(result) => result.asJson
-      case Left(error) => throw FailException(error)
-    }
+    def encode(d: Either[T, A]): Json = d.fold(error => throw FailException(error), _.asJson)
   }
 }


### PR DESCRIPTION
## description
Added `FailSupport` to wiro client, it should be the counterpart of the `FailSupport` in the wiro server. 

The idea there is to decouple the `FailSupport` from the actual `RPCClient` in order to evolve (eventually) later this logic and remove the not-cool part with explicit string mapping (magic numbers?).

## drawbacks and questions
During my tests errors like `case class UserNotFound(userId: Int)` cannot pass the `case class UserNotFound(userId: Int)` in the wiro client because they don't have `application-json` header, moreover they are actually not granted to be JSON serializable-deserializable cause they actually need to just have a `ToHttpResponse` (in the wiro server).

For example the aforementioned `UserNotFound` error is serialized on-the-wire as:
```
HttpResponse(
      status = StatusCodes.NotFound,
      entity = s"User not found: ${error.userId}"
    )
```

This PR should not change change this behaviour, but I'm wondering how this is supposed to work IRL.

## specs
- Made `requestBuilder` private in the `wiro` scope to be tested later;
- Added `WiroDecoder` helper trait;
- Added `FailSupport` to wiro client;
- Restyled `wiroCanFailEncoder` using fold.
