### PR TITLE
Refactor of `RequestBuilder`

### DIFF
--- a/clientAkkaHttp/src/main/scala/RequestBuilder.scala
+++ b/clientAkkaHttp/src/main/scala/RequestBuilder.scala
@@ -39,11 +39,8 @@ class RequestBuilder(
     authority = Authority(host = Host(config.host), port = config.port)
   )
 
-  private[this] def splitTokenArgs(args: Map[String, Json]): (Map[String, Json], Map[String, Json]) = {
-    val tokenCandidates = args.filter { case (_, v) => v.as[wiro.Auth].isRight }
-    val nonTokenArgs = args.filter { case (_, v) => v.as[wiro.Auth].isLeft }
-    (tokenCandidates, nonTokenArgs)
-  }
+  private[this] def splitTokenArgs(args: Map[String, Json]): (Map[String, Json], Map[String, Json]) =
+    args.partition { case (_, value) => value.as[wiro.Auth].isRight }
 
   private[this] def handlingToken(
     httpRequest: HttpRequest,

--- a/clientAkkaHttp/src/main/scala/RequestBuilder.scala
+++ b/clientAkkaHttp/src/main/scala/RequestBuilder.scala
@@ -26,8 +26,8 @@ class RequestBuilder(
     val uri = buildUri(operationName)
 
     val httpRequest = methodMetaData.operationType match {
-      case OperationType.Command(_) => commandHttpRequest(nonTokenArgs, uri)
-      case OperationType.Query(_) => queryHttpRequest(nonTokenArgs, uri)
+      case _: OperationType.Command => commandHttpRequest(nonTokenArgs, uri)
+      case _: OperationType.Query => queryHttpRequest(nonTokenArgs, uri)
     }
     handlingToken(tokenArgs, httpRequest)
   }

--- a/clientAkkaHttp/src/main/scala/RequestBuilder.scala
+++ b/clientAkkaHttp/src/main/scala/RequestBuilder.scala
@@ -51,22 +51,13 @@ class RequestBuilder(
     }
 
   private[this] def commandHttpRequest(nonTokenArgs: Map[String, Json], uri: Uri) = HttpRequest(
-    uri = uri,
-    method = HttpMethods.POST,
-    entity = HttpEntity(
+    method = HttpMethods.POST, uri = uri, entity = HttpEntity(
       contentType = ContentTypes.`application/json`,
       string = nonTokenArgs.asJson.noSpaces
     )
   )
 
-  private[this] def queryHttpRequest(nonTokenArgs: Map[String, Json], uri: Uri): HttpRequest = {
-    val args = nonTokenArgs.mapValues(_.noSpaces)
-    val completeUri = uri.withQuery(Query(args))
-    val method = HttpMethods.GET
-
-    HttpRequest(
-      uri = completeUri,
-      method = method
-    )
-  }
+  private[this] def queryHttpRequest(nonTokenArgs: Map[String, Json], uri: Uri) = HttpRequest(
+    method = HttpMethods.GET, uri = uri.withQuery(Query(nonTokenArgs.mapValues(_.noSpaces)))
+  )
 }

--- a/clientAkkaHttp/src/main/scala/RequestBuilder.scala
+++ b/clientAkkaHttp/src/main/scala/RequestBuilder.scala
@@ -50,7 +50,7 @@ class RequestBuilder(
     tokenCandidates: List[String]
   ): HttpRequest = tokenCandidates match {
     case Nil => httpRequest
-    case List(token) => httpRequest.addHeader(RawHeader("Authorization", s"Token token=$token"))
+    case List(token) => httpRequest.withHeaders(RawHeader("Authorization", s"Token token=$token"))
     case _ => throw new Exception("Only one parameter of wiro.Auth type should be provided")
   }
 

--- a/clientAkkaHttp/src/main/scala/RequestBuilder.scala
+++ b/clientAkkaHttp/src/main/scala/RequestBuilder.scala
@@ -1,10 +1,9 @@
 package wiro
 package client.akkaHttp
 
-import akka.http.scaladsl.model._
+import akka.http.scaladsl.model.{ ContentTypes, HttpEntity, HttpMethods, HttpRequest, Uri }
 import akka.http.scaladsl.model.headers.RawHeader
 import akka.http.scaladsl.model.Uri.{ Host, Authority, Path, Query }
-import akka.http.scaladsl.model.Uri
 
 import io.circe._
 import io.circe.generic.auto._


### PR DESCRIPTION
## description
The idea is to leverage `akka.http.scaladsl.model.Uri` instead of building requests uri manually and enhance/simplify the wiro client `RequestBuilder` in order to improve readability.

## specs
- Centralised `args` management;
- Replaced [`withHeaders`](https://doc.akka.io/api/akka-http/current/akka/http/scaladsl/model/HttpRequest.html#withHeaders(headers:scala.collection.immutable.Seq[akka.http.scaladsl.model.HttpHeader]):akka.http.scaladsl.model.HttpRequest) instead of [`addHeader`](https://doc.akka.io/api/akka-http/current/akka/http/scaladsl/model/HttpRequest.html#addHeader(header:akka.http.javadsl.model.HttpHeader):HttpMessage.this.Self) cause the latter is part of the Java API;
- Restyled `handlingToken` and `splitTokenArgs`;
- Manage auth sooner in order to fail fast;
- Minor stylistic changes;
- Refined imports.
