### PR TITLE
Added tests suite to wiro client

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -80,6 +80,7 @@ lazy val clientAkkaHttp = project
     bintrayPackageLabels := Seq("buildo", "wiro", "wiro-http-client")
   )
   .dependsOn(core)
+  .dependsOn(serverAkkaHttp % "test->test")
 
 lazy val examples = project
   .settings(commonSettings: _*)

--- a/clientAkkaHttp/src/test/scala/AppSpecs.scala
+++ b/clientAkkaHttp/src/test/scala/AppSpecs.scala
@@ -1,0 +1,30 @@
+package wiro
+
+import wiro.client.akkaHttp._
+import wiro.client.akkaHttp.FailSupport._
+
+import autowire._
+
+import akka.http.scaladsl.testkit.ScalatestRouteTest
+import org.scalatest.{ Matchers, WordSpec }
+import org.scalatest.concurrent.ScalaFutures
+
+import io.circe._
+import io.circe.generic.auto._
+
+class WiroSpec extends WordSpec with Matchers with RPCRouteTest with ScalatestRouteTest with ClientDerivationModule with ScalaFutures {
+  import wiro.TestController.{ UserController, User, userRouter }
+  private[this] val rpcClient = new RPCClientTest(
+    deriveClientContext[UserController], userRouter.buildRoute
+  ).apply[UserController]
+
+  "A GET request" when {
+    "it's right" should {
+      "return 200 and content" in {
+        whenReady(rpcClient.read(1).call()) {
+          user => user shouldBe Right(User(1, "read"))
+        }
+      }
+    }
+  }
+}

--- a/clientAkkaHttp/src/test/scala/AppSpecs.scala
+++ b/clientAkkaHttp/src/test/scala/AppSpecs.scala
@@ -1,19 +1,19 @@
 package wiro
 
-import wiro.client.akkaHttp._
-import wiro.client.akkaHttp.FailSupport._
-
-import autowire._
-
 import akka.http.scaladsl.testkit.ScalatestRouteTest
-import org.scalatest.{ Matchers, WordSpec }
-import org.scalatest.concurrent.ScalaFutures
+import autowire._
 
 import io.circe._
 import io.circe.generic.auto._
 
+import org.scalatest.concurrent.ScalaFutures
+import org.scalatest.{ Matchers, WordSpec }
+
+import wiro.client.akkaHttp._
+import wiro.client.akkaHttp.FailSupport._
+import wiro.TestController.{ UserController, User, userRouter }
+
 class WiroSpec extends WordSpec with Matchers with RPCRouteTest with ScalatestRouteTest with ClientDerivationModule with ScalaFutures {
-  import wiro.TestController.{ UserController, User, userRouter }
   private[this] val rpcClient = new RPCClientTest(
     deriveClientContext[UserController], userRouter.buildRoute
   ).apply[UserController]

--- a/clientAkkaHttp/src/test/scala/RPCTestClient.scala
+++ b/clientAkkaHttp/src/test/scala/RPCTestClient.scala
@@ -1,0 +1,19 @@
+package wiro
+
+import cats.implicits._
+import client.akkaHttp.{ RPCClient, RPCClientContext }
+
+import akka.http.scaladsl.testkit.RouteTest
+import akka.http.scaladsl.testkit.TestFrameworkInterface
+import akka.http.scaladsl.model.HttpRequest
+import akka.http.scaladsl.server.Route
+
+import scala.concurrent.Future
+
+trait RPCRouteTest extends RouteTest { this: TestFrameworkInterface ⇒
+  class RPCClientTest(ctx: RPCClientContext[_], route: Route)
+    extends RPCClient(config = Config("localhost", 80), ctx = ctx){
+      override private[wiro] def doHttpRequest(request: HttpRequest) =
+        (request ~> route).response.pure[Future]
+  }
+}

--- a/clientAkkaHttp/src/test/scala/RPCTestClient.scala
+++ b/clientAkkaHttp/src/test/scala/RPCTestClient.scala
@@ -1,16 +1,15 @@
 package wiro
 
+import akka.http.scaladsl.model.HttpRequest
+import akka.http.scaladsl.server.Route
+import akka.http.scaladsl.testkit.{ RouteTest, TestFrameworkInterface }
+
 import cats.implicits._
 import client.akkaHttp.{ RPCClient, RPCClientContext }
 
-import akka.http.scaladsl.testkit.RouteTest
-import akka.http.scaladsl.testkit.TestFrameworkInterface
-import akka.http.scaladsl.model.HttpRequest
-import akka.http.scaladsl.server.Route
-
 import scala.concurrent.Future
 
-trait RPCRouteTest extends RouteTest { this: TestFrameworkInterface ⇒
+trait RPCRouteTest extends RouteTest { this: TestFrameworkInterface =>
   class RPCClientTest(ctx: RPCClientContext[_], route: Route)
     extends RPCClient(config = Config("localhost", 80), ctx = ctx){
       override private[wiro] def doHttpRequest(request: HttpRequest) =


### PR DESCRIPTION
## description
Partially resolve #83, it set up the first stub for the wiro client test suite

## specs
- Added test-only dependency from `serverAkkaHttp` to `clientAkkaHttp`;
- Decomposed `doCall` into multiple overridable methods;
- Added `RPCRouteTest` trait to define `RPCClientTest` helper class.

## misc
Added the need for `FailSupport` import in the tutorial.