### PR TITLE
#99: Json printer cannot be configured in wiro (closes #99)

### DIFF
--- a/serverAkkaHttp/src/main/scala/RPCRouter.scala
+++ b/serverAkkaHttp/src/main/scala/RPCRouter.scala
@@ -12,7 +12,7 @@ import de.heikoseeberger.akkahttpcirce.ErrorAccumulatingCirceSupport._
 
 import FailSupport._
 
-import io.circe.{ Json, JsonObject }
+import io.circe.{ Json, JsonObject, Printer }
 import io.circe.parser._
 
 trait Router extends RPCServer with PathMacro with MetaDataMacro {
@@ -20,6 +20,7 @@ trait Router extends RPCServer with PathMacro with MetaDataMacro {
   def methodsMetaData: Map[String, MethodMetaData]
   def routes: autowire.Core.Router[Json]
   def path: String = tp.last
+  implicit def printer: Printer = Printer.noSpaces
 
   def buildRoute: Route = handleExceptions(exceptionHandler) {
     pathPrefix(path) {

--- a/serverAkkaHttp/src/main/scala/RouterDerivation.scala
+++ b/serverAkkaHttp/src/main/scala/RouterDerivation.scala
@@ -3,23 +3,34 @@ package server.akkaHttp
 
 import scala.language.experimental.macros
 import scala.reflect.macros.blackbox.Context
+import scala.reflect.macros.Universe
 
 import wiro.annotation.path
 
+import io.circe.Printer
+
 trait RouterDerivationModule extends PathMacro with MetaDataMacro with TypePathMacro {
   def deriveRouter[A](a: A): Router = macro RouterDerivationMacro.deriveRouterImpl[A]
+  def deriveRouter[A](a: A, printer: Printer): Router = macro RouterDerivationMacro.deriveRouterImplPrinter[A]
 }
 
 object RouterDerivationMacro extends RouterDerivationModule {
-  def deriveRouterImpl[A: c.WeakTypeTag](c: Context)(a: c.Expr[A]): c.Tree = {
-    import c.universe._
-    val tpe = weakTypeOf[A]
+  //val is required to make universe public
+  class MacroHelper[U <: Universe](val universe: U) {
+    import universe._
 
     //check only annotations of path type
-    val derivePath = tpe.typeSymbol.annotations.collectFirst {
+    //Since universe is public Tree type can be returned
+    def derivePath(tpe: Type): Tree = tpe.typeSymbol.annotations.collectFirst {
       case pathAnnotation if pathAnnotation.tree.tpe <:< weakTypeOf[path] =>
         q"override val path = derivePath[$tpe]"
     }.getOrElse(EmptyTree)
+  }
+
+  def deriveRouterImpl[A: c.WeakTypeTag](c: Context)(a: c.Expr[A]): c.Tree = {
+    import c.universe._
+    val tpe = weakTypeOf[A]
+    val derivePath = new MacroHelper[c.universe.type](c.universe).derivePath(tpe)
 
     q"""
     import wiro.{ OperationType, MethodMetaData }
@@ -28,6 +39,24 @@ object RouterDerivationMacro extends RouterDerivationModule {
       override val routes = route[$tpe]($a)
       override val methodsMetaData = deriveMetaData[$tpe]
       override val tp = typePath[$tpe]
+      $derivePath
+    }
+    """
+  }
+
+  def deriveRouterImplPrinter[A: c.WeakTypeTag](c: Context)(a: c.Expr[A], printer: c.Expr[Printer]): c.Tree = {
+    import c.universe._
+    val tpe = weakTypeOf[A]
+    val derivePath = new MacroHelper[c.universe.type](c.universe).derivePath(tpe)
+
+    q"""
+    import wiro.{ OperationType, MethodMetaData }
+
+    new Router {
+      override val routes = route[$tpe]($a)
+      override val methodsMetaData = deriveMetaData[$tpe]
+      override val tp = typePath[$tpe]
+      override implicit val printer = $printer
       $derivePath
     }
     """

--- a/version.sbt
+++ b/version.sbt
@@ -1,1 +1,1 @@
-version in ThisBuild := "0.6.1-SNAPSHOT"
+version in ThisBuild := "0.6.1"

--- a/version.sbt
+++ b/version.sbt
@@ -1,1 +1,1 @@
-version in ThisBuild := "0.6.1"
+version in ThisBuild := "0.6.2-SNAPSHOT"


### PR DESCRIPTION
Closes #99

## Test Plan

tested locally using examples with
`val doghouseRouter = deriveRouter[DoghouseApi](new DoghouseApiImpl, io.circe.Printer.indented("wat"))`