### PR TITLE
#108: Do not return rejection header when authentication fails (closes #108)

### DIFF
--- a/serverAkkaHttp/src/main/scala/AutowireErrorsSupport.scala
+++ b/serverAkkaHttp/src/main/scala/AutowireErrorsSupport.scala
@@ -42,7 +42,7 @@ object AutowireErrorSupport extends LazyLogging {
     case "token" =>
       logger.info("couldn't find token parameter, rejecting request as unauthorized")
       complete(HttpResponse(
-        status = StatusCodes.Forbidden,
+        status = StatusCodes.Unauthorized,
         entity = s"Unauthorized"
       ))
     case "actionQuery" =>

--- a/serverAkkaHttp/src/main/scala/AutowireErrorsSupport.scala
+++ b/serverAkkaHttp/src/main/scala/AutowireErrorsSupport.scala
@@ -41,9 +41,9 @@ object AutowireErrorSupport extends LazyLogging {
   ): StandardRoute = param match {
     case "token" =>
       logger.info("couldn't find token parameter, rejecting request as unauthorized")
-      reject(AuthenticationFailedRejection(
-        cause = CredentialsRejected,
-        challenge = HttpChallenges.basic("api")
+      complete(HttpResponse(
+        status = StatusCodes.Forbidden,
+        entity = s"Unauthorized"
       ))
     case "actionQuery" =>
       logger.info("required query parameter is missing, method is not allowed")

--- a/serverAkkaHttp/src/test/scala/AppSpecs.scala
+++ b/serverAkkaHttp/src/test/scala/AppSpecs.scala
@@ -193,7 +193,7 @@ class WiroSpec extends WordSpec with Matchers with ScalatestRouteTest {
     "it's authenticated" should {
       "block user without proper token" in {
         Get("/user/nobodyCannaCrossIt") ~> userRouter.buildRoute ~> check {
-          status should be (Unauthorized)
+          status should be (StatusCodes.Unauthorized)
         }
       }
 

--- a/serverAkkaHttp/src/test/scala/AppSpecs.scala
+++ b/serverAkkaHttp/src/test/scala/AppSpecs.scala
@@ -193,14 +193,7 @@ class WiroSpec extends WordSpec with Matchers with ScalatestRouteTest {
     "it's authenticated" should {
       "block user without proper token" in {
         Get("/user/nobodyCannaCrossIt") ~> userRouter.buildRoute ~> check {
-          rejections shouldEqual List(AuthenticationFailedRejection(
-            cause = AuthenticationFailedRejection.CredentialsRejected,
-            challenge = HttpChallenge(
-              scheme = "Basic",
-              realm = "api",
-              params = Map("charset" -> "UTF-8")
-            )
-          ))
+          status should be (Forbidden)
         }
       }
 

--- a/serverAkkaHttp/src/test/scala/AppSpecs.scala
+++ b/serverAkkaHttp/src/test/scala/AppSpecs.scala
@@ -193,7 +193,7 @@ class WiroSpec extends WordSpec with Matchers with ScalatestRouteTest {
     "it's authenticated" should {
       "block user without proper token" in {
         Get("/user/nobodyCannaCrossIt") ~> userRouter.buildRoute ~> check {
-          status should be (Forbidden)
+          status should be (Unauthorized)
         }
       }
 

--- a/version.sbt
+++ b/version.sbt
@@ -1,1 +1,1 @@
-version in ThisBuild := "0.6.8"
+version in ThisBuild := "0.6.9-SNAPSHOT"

--- a/version.sbt
+++ b/version.sbt
@@ -1,1 +1,1 @@
-version in ThisBuild := "0.6.7-SNAPSHOT"
+version in ThisBuild := "0.6.7"

--- a/version.sbt
+++ b/version.sbt
@@ -1,1 +1,1 @@
-version in ThisBuild := "0.6.8-SNAPSHOT"
+version in ThisBuild := "0.6.8"

--- a/version.sbt
+++ b/version.sbt
@@ -1,1 +1,1 @@
-version in ThisBuild := "0.6.7"
+version in ThisBuild := "0.6.8-SNAPSHOT"


### PR DESCRIPTION
Closes #108

## Test Plan

### tests performed
> A Test Plan is used to show what you tested to make sure your code works fine. You should write here all that you did to test, and provide some results of your testing.

> These results can be screenshots, query results, or even just pointers to unit tests that successfully passed.}

### tests not performed (domain coverage)
> At times not everything can be tested, and writing what hasn't been tested is just as important as writing what has been tested.

> An example of partial test is a field displaying 4 possible values. If 3 values are tested, with screenshots, and 1 is not, then it should be mentioned here.}
