### PR TITLE
#121: Wiro fails decoding integers sent as strings (closes #121)

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -39,7 +39,7 @@ lazy val commonSettings = Seq(
   bintrayOrganization := Some("buildo"),
   organization := "io.buildo",
   licenses += ("MIT", url("https://github.com/buildo/wiro/blob/master/LICENSE")),
-  scalaVersion := "2.11.8",
+  scalaVersion := "2.12.4",
   crossScalaVersions := Seq("2.11.8", "2.12.1"),
   libraryDependencies :=
     commonDependencies :+

--- a/serverAkkaHttp/src/test/scala/AppSpecs.scala
+++ b/serverAkkaHttp/src/test/scala/AppSpecs.scala
@@ -190,6 +190,15 @@ class WiroSpec extends WordSpec with Matchers with ScalatestRouteTest {
       }
     }
 
+    "contains query params with integer as only argument" should {
+      "return 200 and content" in {
+        Get("/user/readString?id=1") ~> userRouter.buildRoute ~> check {
+          status should be (OK)
+          responseAs[User] should be (User(1, "read"))
+        }
+      }
+    }
+
     "it's authenticated" should {
       "block user without proper token" in {
         Get("/user/nobodyCannaCrossIt") ~> userRouter.buildRoute ~> check {

--- a/serverAkkaHttp/src/test/scala/TestController.scala
+++ b/serverAkkaHttp/src/test/scala/TestController.scala
@@ -63,6 +63,9 @@ object TestController extends RouterDerivationModule {
     def read(id: Int): Future[Either[UserNotFound, User]]
 
     @query
+    def readString(id: String): Future[Either[UserNotFound, User]]
+
+    @query
     def readQuery(id: Int): Future[Either[UserNotFound, User]]
 
     @command(name = Some("insert"))
@@ -94,6 +97,9 @@ object TestController extends RouterDerivationModule {
       if (id == 1) Right(User(id, "read"))
       else Left(UserNotFound(id))
     }
+
+    def readString(id: String): Future[Either[UserNotFound, User]] =
+      Future(Right(User(1, "read")))
 
     def readQuery(id: Int): Future[Either[UserNotFound, User]] = Future {
       if (id == 1) Right(User(id, "readQuery"))


### PR DESCRIPTION
Closes #121

**idea**:
The only reason why wiro accepts JSON in query strings is to support case classes.
The expected behavior is:
- if the received string is an object, parse it as json (and try to squeeze it into autowire controller)
- otherwise, treat it as a string (default behavior)

## Test Plan

### tests performed
- tested locally
- added unit test
- other tests should work