### PR TITLE
#130: Unbind port when program exit (closes #130)

### DIFF
--- a/serverAkkaHttp/src/main/scala/RPCServer.scala
+++ b/serverAkkaHttp/src/main/scala/RPCServer.scala
@@ -49,7 +49,13 @@ class HttpRPCServerActor(
     case Status.Failure(cause) => logger.error("Unable to bind to ${config.host}:${config.port}", cause)
   }
 
-  Http()
-    .bindAndHandle(route, config.host, config.port)
-    .pipeTo(self)
+  val bindingFuture = Http()
+        .bindAndHandle(route, config.host, config.port)
+        .pipeTo(self)
+
+  scala.sys.addShutdownHook({
+      logger.info("Wiro unbinding on exit")
+      bindingFuture
+        .flatMap(_.unbind())
+    })
 }


### PR DESCRIPTION
Closes #130

## Test Plan

### tests performed

unit tests;

launched examples.userserver and killed to check port unbind