### PR TITLE
Doc: Use execution context from Main and not Global execution context

### DIFF
--- a/docs/src/main/tut/step-by-step-example.md
+++ b/docs/src/main/tut/step-by-step-example.md
@@ -50,8 +50,7 @@ inside the `controllers` object:
 val users = collection.mutable.Map.empty[Int, User] // Users DB
 
 // API implementation
-class UsersApiImpl() extends UsersApi {
-  import scala.concurrent.ExecutionContext.Implicits.global
+class UsersApiImpl(implicit ec: ExecutionContext) extends UsersApi {
 
   override def getUser(
     id: Int


### PR DESCRIPTION
I'm wondering if it is better to use implicit execution context coming from Main instead of Global execution context